### PR TITLE
祝日の表示と予定追加モーダルと予定一覧モーダルの実装

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,6 @@
     transform: rotate(360deg);
   }
 }
+.holiday-event {
+  background-color: #ffdada !important; /* ピンク色にする */
+}

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ function App() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isListModalOpen, setIsListModalOpen] = useState(false);
   const [newEvent, setNewEvent] = useState({ title: "", date: "", time: "" });
+  const [calendarKey, setCalendarKey] = useState(0); // 再描画用のキー
 
   useEffect(() => {
     const fetchHolidays = async () => {
@@ -18,20 +19,54 @@ function App() {
         console.error("APIキーが設定されていません");
         return;
       }
-      const url = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${API_KEY}`;
+      const url = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${API_KEY}&hl=ja`;
 
       try {
         const response = await fetch(url);
         const data = await response.json();
         console.log("取得した祝日データ:", data.items); // デバッグ
+        console.log(data);
         if (data.items) {
+          const holidayTranslations = {
+            "New Year's Day": "元日",
+            "January 1 Bank Holiday": " ",
+            "January 2 Bank Holiday": " ",
+            "January 3 Bank Holiday": " ",
+            "December 31 Bank Holiday": "大晦日",
+            "Coming of Age Day": "成人の日",
+            "National Foundation Day": "建国記念の日",
+            "Emperor's Birthday observed": "振り返り休日",
+            "Dolls' Festival/Girls' Festival": "ひな祭り",
+            "Spring Equinox": "春分の日",
+            "Shōwa Day": "昭和の日",
+            "Constitution Memorial Day": "憲法記念日",
+            "Greenery Day": "みどりの日",
+            "Children's Day": "こどもの日",
+            "Greenery Day observed": "振り返り休日",
+            "Mother's Day": "母の日",
+            "Star Festival": "七夕",
+            "Sea Day": "海の日",
+            "Mountain Day": "山の日",
+            "Respect for the Aged Day": "敬老の日",
+            "Autumn Equinox": "秋分の日",
+            "Sports Day": "体育の日",
+            "Culture Day": "文化の日",
+            "7-5-3 Day": "七五三",
+            "Labor Thanksgiving Day": "勤労感謝の日",
+            "Labor Thanksgiving Day observed": "振り返り休日",
+            "Emperor's Birthday": "天皇誕生日",
+          };
           const holidays = data.items.map((event) => ({
-            title: event.summary || "祝日",
+            title: holidayTranslations[event.summary] || event.summary, // 日本語があれば変換
             start: event.start?.date || event.start?.dateTime, // ここは `date` ではなく `start` に統一
-            backgroundColor: "#FFDADA", // 背景色を適用
+            display: "background", // ここで背景イベントにする！
+            backgroundColor: "#FFDADA", // 祝日の背景をピンクにする
             className: "holiday-event", // カスタムクラスを追加（必要ならCSSで設定）
           }));
+          console.log("変換後の祝日イベント", holidays); // ここで確認！
+
           setHolidayEvents(holidays);
+          console.log("祝日データが更新されました:", holidays);
         }
       } catch (error) {
         console.error("祝日の取得中にエラーが発生しました:", error);
@@ -40,6 +75,11 @@ function App() {
 
     fetchHolidays();
   }, []);
+
+  // holidayEvents が更新されたら、カレンダーを再描画する
+  useEffect(() => {
+    setCalendarKey((prevKey) => prevKey + 1);
+  }, [holidayEvents]);
 
   const addEvent = () => {
     if (newEvent.title && newEvent.date) {
@@ -62,6 +102,7 @@ function App() {
   return (
     <div className="App">
       <Calendar
+        key={calendarKey} // 変更: カレンダーを強制的に再描画
         events={[...userEvents, ...holidayEvents]}
         onOpenAddModal={() => {
           console.log("予定追加モーダルを開きます"); // デバッグ用

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -28,15 +28,21 @@ const Calendar = ({ events, onOpenAddModal, onOpenListModal }) => {
       locales={[jaLocale]}
       locale="ja"
       dayMaxEventRows={5}
-      eventDidMount={(info) => {
-        // 通常のイベントの背景色を適用
-        const bgColor = info.event.extendedProps?.backgroundColor || "#007bff";
-        info.el.style.backgroundColor = bgColor;
-      }}
+      // eventDidMount={(info) => {
+      //   // 通常のイベントの背景色を適用
+      //   const bgColor = info.event.extendedProps?.backgroundColor || "#007bff";
+      //   info.el.style.backgroundColor = bgColor;
+      // }}
       dayCellDidMount={(info) => {
         const date = info.date;
         const day = date.getDay(); // 0: 日曜, 6: 土曜
-        const formattedDate = date.toISOString().split("T")[0]; // YYYY-MM-DD 形式
+        const formattedDate = info.date
+          .toLocaleDateString("ja-JP", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          })
+          .replace(/\//g, "-");
 
         // 祝日リストにその日が含まれていたら背景色を変更
         if (
@@ -46,14 +52,14 @@ const Calendar = ({ events, onOpenAddModal, onOpenListModal }) => {
               event.backgroundColor === "#FFDADA"
           )
         ) {
-          info.el.style.backgroundColor = "#FFDAFA"; // 祝日の背景色
+          info.el.style.backgroundColor = "#FFDADA"; // 祝日の背景色、あとで変更
         }
 
         // 土曜日は薄い青、日曜日は薄い赤
         if (day === 6) {
           info.el.style.backgroundColor = "#E0F7FA"; // 土曜の背景色（薄い水色）
         } else if (day === 0) {
-          info.el.style.backgroundColor = "#FFEBEE"; // 日曜の背景色（薄い赤）
+          info.el.style.backgroundColor = "#FFDADA"; // 日曜の背景色（薄い赤）
         }
       }}
     />


### PR DESCRIPTION
祝日の表示と予定追加モーダルと予定一覧モーダルの実装
・FullCalenderライブラリを使いデザインを確定
・予定に関してモーダルを作成
・土日祝日の背景色実装
・祝日の詳細をGoogleAPIから引っ張ってくる、表記を日本語に変換する。
・holidayEvents が更新されたら、カレンダーを再描画するようにuseEffectを追加
