### PR TITLE
ヘッダーの修正、一覧モーダルの整備

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -39,3 +39,12 @@
 .holiday-event {
   background-color: #ffdada !important; /* ピンク色にする */
 }
+
+.fc-toolbar-chunk {
+  display: flex !important; /* フレックスボックスで横並び */
+  align-items: center; /* 垂直方向の中央揃え */
+  gap: 10px; /* ボタンとタイトルの間隔 */
+}
+.fc-toolbar.fc-header-toolbar {
+  margin-top: 1.5rem;
+}

--- a/src/Calendar.css
+++ b/src/Calendar.css
@@ -1,0 +1,11 @@
+.fc-toolbar.fc-header-toolbar {
+  display: flex !important; /* ヘッダー全体をflexboxに */
+  justify-content: space-between !important; /* 左右に配置 */
+  align-items: center !important; /* 中央揃え */
+}
+
+.fc-toolbar.fc-header-toolbar .fc-toolbar-chunk {
+  display: flex !important; /* ツールバーチャンク（各エリア）もflex */
+  align-items: center !important;
+  gap: 10px !important; /* ボタンとタイトルの間隔を調整 */
+}

--- a/src/components/AddEventModal.css
+++ b/src/components/AddEventModal.css
@@ -22,6 +22,7 @@
 
 .modal-button {
   margin-top: 10px;
+  padding: 10px;
 }
 
 .modal-button button {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -11,8 +11,7 @@ const Calendar = ({ events, onOpenAddModal, onOpenListModal }) => {
       plugins={[dayGridPlugin, interactionPlugin]}
       initialView="dayGridMonth"
       headerToolbar={{
-        left: "prev,next",
-        center: "title",
+        left: "prev title next",
         right: "customAddEvent customViewEvents",
       }}
       customButtons={{

--- a/src/components/EventListModal.js
+++ b/src/components/EventListModal.js
@@ -7,17 +7,19 @@ const EventListModal = ({ isOpen, onClose, events }) => {
     <div className="modal">
       <div className="modal-content">
         <h2>予定一覧</h2>
-        {events.length > 0 ? (
-          <ul>
-            {events.map((event, index) => (
-              <li key={index}>
-                {event.start.replace("T", " ")}: {event.title}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p>現在予定はありません</p>
-        )}
+        <div className="event-list">
+          {events.length > 0 ? (
+            <ul className="event-items">
+              {events.map((event, index) => (
+                <li key={index} className="event-item">
+                  {event.start.replace("T", " ")}: {event.title}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>現在予定はありません</p>
+          )}
+        </div>
         <div className="modal-buttons">
           <button onClick={onClose}>閉じる</button>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,40 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+.fc-toolbar-chunk {
+  display: flex !important; /* フレックスボックスで横並び */
+  align-items: center; /* 垂直方向の中央揃え */
+  gap: 10px; /* ボタンとタイトルの間隔 */
+}
+.fc-toolbar.fc-header-toolbar {
+  margin-top: 1.5rem;
+}
+.event-item {
+  background-color: #87cefa; /* 薄い青 */
+  padding: 10px;
+  margin: 5px 0;
+  border-radius: 5px;
+  list-style: none;
+  word-wrap: break-word; /* 長い単語を折り返す */
+  white-space: normal; /* 必要に応じて改行 */
+  overflow-wrap: break-word; /* 長い単語を折り返す */
+  max-width: 100%; /* 親要素の幅を超えないようにする */
+}
+.event-items {
+  padding: 0px 10px;
+}
+.fc-toolbar-chunk {
+  display: flex !important; /* フレックスボックスで横並び */
+  align-items: center; /* 垂直方向の中央揃え */
+  gap: 10px; /* ボタンとタイトルの間隔 */
+}
+.fc-toolbar.fc-header-toolbar {
+  margin-top: 1.5rem;
+}
+.event-list {
+  max-height: 300px; /* 予定一覧の最大高さ */
+  overflow-y: auto; /* スクロール可能にする */
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+}


### PR DESCRIPTION
・ヘッダーの要素の位置を修正
・予定一覧モーダルを見やすく豪華にする
（
追加した予定の背景色を追加、予定の文字数が多かった時に枠からはみ出ないように制御、追加した予定がたくさんある時下にスクロール可能）